### PR TITLE
Enable to show only foreign language

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1034,6 +1034,20 @@ files = [
 ]
 
 [[package]]
+name = "langdetect"
+version = "1.0.9"
+description = "Language detection library ported from Google's language-detection."
+optional = false
+python-versions = "*"
+files = [
+    {file = "langdetect-1.0.9-py2-none-any.whl", hash = "sha256:7cbc0746252f19e76f77c0b1690aadf01963be835ef0cd4b56dddf2a8f1dfc2a"},
+    {file = "langdetect-1.0.9.tar.gz", hash = "sha256:cbc1fef89f8d062739774bd51eda3da3274006b3661d199c2655f6b3f6d605a0"},
+]
+
+[package.dependencies]
+six = "*"
+
+[[package]]
 name = "markupsafe"
 version = "2.1.5"
 description = "Safely add untrusted strings to HTML/XML markup."
@@ -2296,4 +2310,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "c1bb8d57df38724163f66e778e1bf8cef8003ad2a3a5f521c1d21fc4124d296d"
+content-hash = "2d3506583241cc31c0bcc92f34b0d4b3fb48b221f0e89ec6967d9f2be755af1e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ sentencepiece = "^0.2.0"
 protobuf = "^5.26.1"
 numpy = "^1.26.4"
 scipy = "^1.13.0"
+langdetect = "^1.0.9"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/sentencepiece_merger.py
+++ b/sentencepiece_merger.py
@@ -4,6 +4,8 @@ import argparse
 import math
 import numpy as np
 from scipy.special import logsumexp
+import re
+from langdetect import detect
 
 
 NORMALIZE_BASE = False
@@ -70,8 +72,8 @@ def load_model(model_path):
     return m
 
 
-def save_model(model, model_path):
-    with open(model_path, "wb") as f:
+def save_model(model, output_path):
+    with open(output_path, "wb") as f:
         f.write(model.SerializeToString())
 
 
@@ -92,9 +94,33 @@ def find_unkown_piece(model):
     return None
 
 
+english_pattern = re.compile(r'[A-Za-z0-9\s!\"#$%&\'()*+,\-./:;<=>?@\[\\\]^_`{|}~▁]+')
+japanese_pattern = re.compile(r'[ぁ-んァ-ン一-龯々〆〤▁]+')
+
+
+def detect_language(piece):
+    if english_pattern.fullmatch(piece):
+        return "en"
+    elif japanese_pattern.fullmatch(piece):
+        return "ja"
+    else:
+        try:
+            return detect(piece)
+        except Exception:
+            return "unknown"
+
+
 def print_pieces(model):
     for sp in model.pieces:
         print(sp.type, sp.piece, sp.score)
+
+
+def print_non_english_japanese_pieces(model):
+    for sp in model.pieces:
+        lang = detect_language(sp.piece)
+        if lang != "en" and lang != "ja":
+            lang = detect_language(sp.piece)
+            print(sp.type, sp.piece, lang, sp.score)
 
 
 def print_special_pieces(model, exclude_byte=True):

--- a/show_model.py
+++ b/show_model.py
@@ -1,19 +1,23 @@
-from sentencepiece_merger import load_model, show_metrics_of_model, print_pieces
+from sentencepiece_merger import load_model, show_metrics_of_model, print_pieces, print_non_english_japanese_pieces
 
 import argparse
 
 
-def show_model(model_path):
+def show_model(model_path, only_foreign=False):
     model = load_model(model_path)
     show_metrics_of_model(model, model_path)
-    print_pieces(model)
+    if only_foreign:
+        print_non_english_japanese_pieces(model)
+    else:
+        print_pieces(model)
 
 
 def main():
     parser = argparse.ArgumentParser(description='show SentencePiece model')
     parser.add_argument('model', type=str, help='Path to the SentencePiece model')
+    parser.add_argument('--only-foreign', action='store_true', default=False, help='Show only foreign(not english/japanese) pieces')
     args = parser.parse_args()
-    show_model(args.model)
+    show_model(args.model, args.only_foreign)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Why

英語でも日本語でもないものを除外したい

## What

```
poetry run python show_model.py --only-foreign data/test_merged.model
```

で以下のような結果が見えるようなものを作った。
除外はこれでまず見てからやってみる。

```
1 ° unknown -11.45600700378418
1 × ko -10.617124557495117
1 à fr -13.713312149047852
1 á hu -13.49829387664795
1 é hu -13.268815994262695
1 ÷ unknown -13.63640022277832
1 ā lv -11.690720558166504
1 ī lv -13.268781661987305
1 α el -13.082253456115723
1 μ el -13.268817901611328
1 ‐ unknown -11.301270484924316
1 – unknown -11.33780288696289
1 — unknown -12.698320388793945
1 ― unknown -10.109180450439453
1 “ unknown -10.266789436340332
1 ” unknown -10.031745910644531
1 ※ unknown -10.909530639648438
1 ← unknown -12.241106986999512
1 → unknown -8.641489028930664
1 ⇒ unknown -12.153348922729492
1 ⇔ unknown -13.321442604064941
1 − lt -13.376983642578125
1 ≒ unknown -11.375629425048828
1 ─ unknown -10.799067497253418
1 ▁※ unknown -10.07682991027832
1 ▁「 zh-tw -7.552701950073242
1 ■ unknown -9.986449241638184
1 □ unknown -11.733966827392578
1 △ unknown -13.218796730041504
1 ○ unknown -11.016230583190918
1 ● unknown -13.040580749511719
1 ☆ unknown -13.321403503417969
1 、 zh-cn -3.1903727054595947
1 。 zh-cn -3.439631462097168
1 〇 unknown -12.889379501342773
1 〈 ko -11.043598175048828
1 〉 ko -11.077404975891113
1 《 zh-cn -12.317328453063965
1 》 ko -12.317338943481445
1 「 zh-tw -5.461330413818359
1 」 zh-tw -5.275298118591309
1 」( zh-tw -8.37412166595459
1 」、「 zh-tw -9.338199615478516
1 」「 zh-tw -8.295503616333008
1 【 unknown -10.958648681640625
1 】 unknown -10.95865249633789
1 〒 unknown -11.552559852600098
1 〔 unknown -10.229278564453125
1 〕 unknown -10.229279518127441
1 〘 unknown -13.32867431640625
1 〙 unknown -16.808025360107422
```

### 実装上の工夫

langdetectを使ってやろうとした。

ただアルファベット構成のやつもいろいろなものになり

```
1 empura pt -8.607518196105957
1 en nl -6.293299674987793
1 ence es -7.3249030113220215
1 ent nl -6.40728235244751
1 ept ro -8.525249481201172
1 er da -5.3329339027404785
1 es fr -6.4840288162231445
1 est fr -7.824533939361572
1 etic fr -8.955217361450195
1 ever da -7.717202186584473
1 f da -5.729281902313232
1 fresh en -9.329354286193848
1 fter da -8.079307556152344
1 ful ro -7.590817928314209
1 g cy -5.2654128074646
```

日本語っぽいやつもko,zh-cn,zh-twとなる問題

```
1 用意 ko -10.666736602783203
1 用語 ko -10.006501197814941
1 田中 zh-cn -10.030263900756836
1 田村 zh-cn -10.126480102539062
1 田辺 zh-cn -9.615313529968262
1 由来 ko -9.41804027557373
1 甲斐 ko -10.126128196716309
1 甲斐国 ko -10.572171211242676
1 男女 zh-cn -10.581059455871582
1 男子 ko -9.838651657104492
1 男性 ko -9.827073097229004
1 男爵 ko -10.673336029052734
1 画家 zh-cn -10.33320426940918
1 留学 zh-cn -10.137360572814941
1 留守 ko -10.411014556884766
1 番号 ko -10.477039337158203
1 番目 ko -10.460753440856934
1 番線 ko -10.483551025390625
1 異説 ko -10.637344360351562
1 畿内 zh-cn -9.79297161102295
1 疑問 zh-tw -10.391711235046387
```

があったので正規表現でかなりのものを除外し、その後でlangdetectを使った